### PR TITLE
Test - Confirm safari handles auth cookie

### DIFF
--- a/api/utils/jwt.js
+++ b/api/utils/jwt.js
@@ -28,7 +28,7 @@ function verifyToken(token, secret) {
 
 export function generateAccessToken(userId, email) {
   const secret = getJwtSecret();
-  return generateToken(userId, email, "1d", secret);
+  return generateToken(userId, email, "30s", secret);
 }
 
 export function generateRefreshToken(userId, email) {


### PR DESCRIPTION
Limit to cookie to 30s to quickly verify Safari handles them