### PR TITLE
Pin frontend web service to Node 24.18.0 on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,5 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+      - key: NODE_VERSION
+        value: 24.18.0


### PR DESCRIPTION
Angular 22's CLI requires Node 22.22.3+, and the frontend deploy started failing after the v22 upgrade since Render was still resolving an older default. Setting NODE_VERSION directly takes top priority in Render's version resolution.