### PR TITLE
hotfix: allowlist production host for Angular 22 SSR host validation

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -41,6 +41,9 @@
             "outputMode": "server",
             "ssr": {
               "entry": "src/server.ts"
+            },
+            "security": {
+              "allowedHosts": ["nextjapan.jotek.dev"]
             }
           },
           "configurations": {


### PR DESCRIPTION
Angular 22's SSR engine (AngularNodeAppEngine) added strict Host-header validation to prevent SSRF/host-header-injection attacks, and rejects any request whose Host header isn't explicitly allowlisted. Since nextjapan.jotek.dev was never added to the new security.allowedHosts build option, every production request has been getting rejected with a 400 since the v22 deploy:

  Header "host" with value "nextjapan.jotek.dev" is not allowed.

Reproduced locally against a real production build/server with the production Host header before and after this change to confirm root cause and fix.