### PR TITLE
Migrate frontend to 100% OnPush change detection

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -14,7 +14,7 @@ import { ErrorBarComponent } from "./core/ui/error-bar/error-bar.component";
     VisitTrackerComponent
   ],
   templateUrl: './app.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './app.component.scss'
 })
 export class AppComponent {

--- a/frontend/src/app/core/analytics/visit-tracker/visit-tracker.component.ts
+++ b/frontend/src/app/core/analytics/visit-tracker/visit-tracker.component.ts
@@ -9,7 +9,7 @@ import { filter, switchMap } from 'rxjs/operators';
 @Component({
   selector: 'app-visit-tracker',
   template: '', // invisible
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
 export class VisitTrackerComponent implements OnInit {

--- a/frontend/src/app/core/auth/login-button/login-button.component.ts
+++ b/frontend/src/app/core/auth/login-button/login-button.component.ts
@@ -6,7 +6,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-login-button',
   imports: [NextButtonComponent],
   templateUrl: './login-button.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './login-button.component.scss'
 })
 export class LoginButtonComponent {

--- a/frontend/src/app/core/auth/login/login-steps/login-steps.component.ts
+++ b/frontend/src/app/core/auth/login/login-steps/login-steps.component.ts
@@ -22,7 +22,7 @@ import { SignUpFormComponent } from './sign-up-form/sign-up-form.component';
     PlanPaymentComponent
   ],
   templateUrl: './login-steps.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './login-steps.component.scss'
 })
 export class LoginStepsComponent implements OnInit {

--- a/frontend/src/app/core/auth/login/login-steps/plan-payment/plan-payment.component.ts
+++ b/frontend/src/app/core/auth/login/login-steps/plan-payment/plan-payment.component.ts
@@ -18,7 +18,7 @@ import { PaymentForm } from './payment.form';
   selector: 'app-plan-payment',
   imports: [RouterLink, ReactiveFormsModule, MatFormFieldModule, MatInputModule, NextButtonComponent],
   templateUrl: './plan-payment.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './plan-payment.component.scss'
 })
 export class PlanPaymentComponent implements OnInit {
@@ -68,7 +68,6 @@ export class PlanPaymentComponent implements OnInit {
     ).subscribe({
       next: (res) => {
         if (res.success && res.data) {
-          this.user().subscriptionPlan = res.data.subscriptionPlan;
           this.authService.updateUserData(res.data);
           this.updatePayment.emit(res.data.subscriptionPlan);
         }

--- a/frontend/src/app/core/auth/login/login-steps/select-plan/plan-card/plan-card.component.ts
+++ b/frontend/src/app/core/auth/login/login-steps/select-plan/plan-card/plan-card.component.ts
@@ -7,7 +7,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-plan-card',
   imports: [CurrencyPipe, NextButtonComponent],
   templateUrl: './plan-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './plan-card.component.scss'
 })
 export class PlanCardComponent {

--- a/frontend/src/app/core/auth/login/login-steps/select-plan/select-plan.component.ts
+++ b/frontend/src/app/core/auth/login/login-steps/select-plan/select-plan.component.ts
@@ -6,7 +6,7 @@ import { PlanCardComponent } from './plan-card/plan-card.component';
   selector: 'app-select-plan',
   imports: [PlanCardComponent],
   templateUrl: './select-plan.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './select-plan.component.scss'
 })
 export class SelectPlanComponent implements OnChanges {

--- a/frontend/src/app/core/auth/login/login-steps/sign-in/sign-in.component.ts
+++ b/frontend/src/app/core/auth/login/login-steps/sign-in/sign-in.component.ts
@@ -12,7 +12,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-sign-in',
   imports: [FormsModule, MatFormFieldModule, MatInputModule, UserAvatarComponent, NextButtonComponent],
   templateUrl: './sign-in.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './sign-in.component.scss'
 })
 export class SignInComponent implements OnInit {

--- a/frontend/src/app/core/auth/login/login-steps/sign-up-form/sign-up-form.component.ts
+++ b/frontend/src/app/core/auth/login/login-steps/sign-up-form/sign-up-form.component.ts
@@ -10,7 +10,7 @@ import { NewUserForm } from './new-user.form';
   selector: 'app-sign-up-form',
   imports: [ReactiveFormsModule, MatFormFieldModule, MatInputModule, NextButtonComponent],
   templateUrl: './sign-up-form.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './sign-up-form.component.scss'
 })
 export class SignUpFormComponent {

--- a/frontend/src/app/core/auth/login/login.component.ts
+++ b/frontend/src/app/core/auth/login/login.component.ts
@@ -13,7 +13,7 @@ import { LoginStepsComponent } from "./login-steps/login-steps.component";
   selector: 'app-login',
   imports: [MatProgressSpinnerModule, LoginStepsComponent, NgxSpinnerComponent],
   templateUrl: './login.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './login.component.scss'
 })
 export class LoginComponent implements OnInit {

--- a/frontend/src/app/core/auth/logout/logout.component.ts
+++ b/frontend/src/app/core/auth/logout/logout.component.ts
@@ -11,7 +11,7 @@ import { delay } from 'rxjs';
   imports: [MatProgressSpinnerModule, NgxSpinnerComponent],
   templateUrl: './logout.component.html',
   styleUrl: './logout.component.scss',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: { '[class.fade-in-animate]': 'true' }
 })
 export class LogoutComponent implements OnInit {

--- a/frontend/src/app/core/layout/header/color-bar/color-bar.component.ts
+++ b/frontend/src/app/core/layout/header/color-bar/color-bar.component.ts
@@ -4,7 +4,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   selector: 'app-color-bar',
   imports: [],
   templateUrl: './color-bar.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './color-bar.component.scss'
 })
 export class ColorBarComponent {

--- a/frontend/src/app/core/layout/header/navbar/navbar.component.ts
+++ b/frontend/src/app/core/layout/header/navbar/navbar.component.ts
@@ -10,7 +10,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-navbar',
   imports: [AppLogoComponent, EventSearchAutocompleteComponent, NextButtonComponent, RouterLink],
   templateUrl: './navbar.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './navbar.component.scss',
 })
 export class NavbarComponent {

--- a/frontend/src/app/core/layout/layout.component.ts
+++ b/frontend/src/app/core/layout/layout.component.ts
@@ -16,7 +16,7 @@ import { SignInBannerComponent } from './sign-in-banner/sign-in-banner.component
   selector: 'app-layout',
   imports: [NgComponentOutlet, HeaderComponent, FooterComponent, SignInBannerComponent, DialogComponent],
   templateUrl: './layout.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './layout.component.scss'
 })
 export class LayoutComponent {

--- a/frontend/src/app/core/ui/app-logo/app-logo.component.ts
+++ b/frontend/src/app/core/ui/app-logo/app-logo.component.ts
@@ -8,7 +8,7 @@ import { ThemeService } from '@app/core/services/theme.service';
   selector: 'app-logo',
   imports: [NgOptimizedImage],
   templateUrl: './app-logo.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './app-logo.component.scss'
 })
 export class AppLogoComponent {

--- a/frontend/src/app/core/ui/error-bar/error-bar.component.ts
+++ b/frontend/src/app/core/ui/error-bar/error-bar.component.ts
@@ -7,7 +7,7 @@ import { ErrorService } from '@app/core/services/error.service';
   selector: 'app-error-bar',
   imports: [],
   templateUrl: './error-bar.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './error-bar.component.scss'
 })
 export class ErrorBarComponent {

--- a/frontend/src/app/features/ai/pages/ai-event-designer-page/content-generator/content-generator.component.ts
+++ b/frontend/src/app/features/ai/pages/ai-event-designer-page/content-generator/content-generator.component.ts
@@ -17,7 +17,7 @@ import { AiPromptsForm } from './ai-prompts.form';
   selector: 'app-content-generator',
   imports: [TitleCasePipe, FormsModule, MatFormFieldModule, MatSelectModule, MatInputModule, TextFieldModule, ReactiveFormsModule, NextButtonComponent],
   templateUrl: './content-generator.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './content-generator.component.scss'
 })
 export class ContentGeneratorComponent implements OnInit {

--- a/frontend/src/app/features/ai/pages/ai-event-page/ai-event-header/ai-event-header.component.ts
+++ b/frontend/src/app/features/ai/pages/ai-event-page/ai-event-header/ai-event-header.component.ts
@@ -8,7 +8,7 @@ import { EventData } from '@app/features/events/models/event-data.model';
   selector: 'app-ai-event-header',
   imports: [NgOptimizedImage],
   templateUrl: './ai-event-header.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './ai-event-header.component.scss'
 })
 export class AiEventHeaderComponent {

--- a/frontend/src/app/features/ai/ui/ai-surprise/ai-surprise.component.ts
+++ b/frontend/src/app/features/ai/ui/ai-surprise/ai-surprise.component.ts
@@ -9,7 +9,7 @@ import { NgxSpinnerComponent, NgxSpinnerService } from 'ngx-spinner';
   selector: 'app-ai-surprise',
   imports: [NgxSpinnerComponent, NextButtonComponent],
   templateUrl: './ai-surprise.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './ai-surprise.component.scss'
 })
 export class AiSurpriseComponent implements OnInit {

--- a/frontend/src/app/features/events/pages/event-page/components/event-coordinators/event-coordinators.component.ts
+++ b/frontend/src/app/features/events/pages/event-page/components/event-coordinators/event-coordinators.component.ts
@@ -6,7 +6,7 @@ import { AvatarComponent } from "@app/features/user/ui/avatar/avatar.component";
   selector: 'app-event-coordinators',
   imports: [AvatarComponent],
   templateUrl: './event-coordinators.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-coordinators.component.scss'
 })
 export class EventCoordinatorsComponent {

--- a/frontend/src/app/features/events/pages/event-page/components/event-hero/event-hero.component.ts
+++ b/frontend/src/app/features/events/pages/event-page/components/event-hero/event-hero.component.ts
@@ -15,7 +15,7 @@ import { RegistrationStatusCardComponent } from "@app/features/registrations/ui/
   imports: [NgOptimizedImage, EventLikeButtonComponent, EventShareButtonComponent, RegistrationStatusCardComponent],
   templateUrl: './event-hero.component.html',
   styleUrl: './event-hero.component.scss',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '(window:scroll)': 'handleScroll()'
   }

--- a/frontend/src/app/features/events/pages/event-page/components/event-map/event-map.component.ts
+++ b/frontend/src/app/features/events/pages/event-page/components/event-map/event-map.component.ts
@@ -13,7 +13,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-event-map',
   imports: [EventDateCardComponent, NextButtonComponent],
   templateUrl: './event-map.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-map.component.scss'
 })
 export class EventMapComponent {

--- a/frontend/src/app/features/events/pages/event-page/components/event-opportunities/event-opportunities.component.ts
+++ b/frontend/src/app/features/events/pages/event-page/components/event-opportunities/event-opportunities.component.ts
@@ -7,7 +7,7 @@ import { RegistrationRequestButtonComponent } from '@app/features/registrations/
   selector: 'app-event-opportunities',
   imports: [RegistrationRequestButtonComponent, EventOpportunityCardComponent],
   templateUrl: './event-opportunities.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-opportunities.component.scss'
 })
 export class EventOpportunitiesComponent {

--- a/frontend/src/app/features/events/pages/search-results-page/search-card/search-card.component.ts
+++ b/frontend/src/app/features/events/pages/search-results-page/search-card/search-card.component.ts
@@ -9,7 +9,7 @@ import { EventDateCardComponent } from "@app/features/events/ui/event-date-card/
   selector: 'app-search-card',
   imports: [NgOptimizedImage, EventDateCardComponent],
   templateUrl: './search-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './search-card.component.scss'
 })
 export class SearchCardComponent implements OnInit {

--- a/frontend/src/app/features/events/ui/event-carousel/event-card/event-card.component.ts
+++ b/frontend/src/app/features/events/ui/event-carousel/event-card/event-card.component.ts
@@ -11,7 +11,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   standalone: true,
   imports: [NgOptimizedImage, RouterLink, NextButtonComponent],
   templateUrl: './event-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-card.component.scss'
 })
 export class EventCardComponent {

--- a/frontend/src/app/features/events/ui/event-carousel/event-carousel.component.ts
+++ b/frontend/src/app/features/events/ui/event-carousel/event-carousel.component.ts
@@ -21,8 +21,7 @@ export class EventCarouselComponent {
 
   events = input<EventData[]>([]);
   sortedEvents = computed(() => {
-    const sorted = [...this.events().sort(this.sortByDate)];
-    return sorted
+    return [...this.events()].sort(this.sortByDate);
   });
   ssrMode = computed(() => !isPlatformBrowser(this.platformId));
   showIndicators = toSignal(

--- a/frontend/src/app/features/events/ui/event-date-card/event-date-card.component.ts
+++ b/frontend/src/app/features/events/ui/event-date-card/event-date-card.component.ts
@@ -7,7 +7,7 @@ import { EventCalendarDate } from '@app/features/events/models/event-calendar-da
   selector: 'app-event-date-card',
   imports: [LowerCasePipe],
   templateUrl: './event-date-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-date-card.component.scss'
 })
 export class EventDateCardComponent {

--- a/frontend/src/app/features/events/ui/event-like-button/event-like-button.component.ts
+++ b/frontend/src/app/features/events/ui/event-like-button/event-like-button.component.ts
@@ -11,7 +11,7 @@ import { finalize, forkJoin, of } from 'rxjs';
   selector: 'app-event-like-button',
   imports: [MatRippleModule],
   templateUrl: './event-like-button.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-like-button.component.scss'
 })
 export class EventLikeButtonComponent implements OnChanges {

--- a/frontend/src/app/features/events/ui/event-location-card/event-location-card.component.ts
+++ b/frontend/src/app/features/events/ui/event-location-card/event-location-card.component.ts
@@ -6,7 +6,7 @@ import { EventLocation } from '@app/features/events/models/event-location.model'
   imports: [],
   templateUrl: './event-location-card.component.html',
   styleUrl: './event-location-card.component.scss',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
   .centered {
     align-items: center;

--- a/frontend/src/app/features/events/ui/event-opportunity-card/event-opportunity-card.component.ts
+++ b/frontend/src/app/features/events/ui/event-opportunity-card/event-opportunity-card.component.ts
@@ -6,7 +6,7 @@ import { EventOpportunity } from '@app/features/events/models/event-opportunity.
   selector: 'app-event-opportunity-card',
   imports: [],
   templateUrl: './event-opportunity-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-opportunity-card.component.scss'
 })
 export class EventOpportunityCardComponent {

--- a/frontend/src/app/features/events/ui/event-search-autocomplete/event-search-autocomplete.component.ts
+++ b/frontend/src/app/features/events/ui/event-search-autocomplete/event-search-autocomplete.component.ts
@@ -15,7 +15,7 @@ import { debounceTime, filter, of, switchMap } from 'rxjs';
   imports: [ReactiveFormsModule, FormsModule, MatAutocompleteModule, MatButtonModule, MatFormFieldModule, MatInputModule],
   templateUrl: './event-search-autocomplete.component.html',
   styleUrl: './event-search-autocomplete.component.scss',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.show]': 'isComponentActive()',
     '[class.open]': 'isOpen()'

--- a/frontend/src/app/features/events/ui/event-share-button/event-share-button.component.ts
+++ b/frontend/src/app/features/events/ui/event-share-button/event-share-button.component.ts
@@ -16,7 +16,7 @@ import { forkJoin } from 'rxjs';
   selector: 'app-event-share-button',
   imports: [MatButtonModule, MatRippleModule, MatMenuModule, MatTooltipModule],
   templateUrl: './event-share-button.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-share-button.component.scss'
 })
 export class EventShareButtonComponent implements OnInit {

--- a/frontend/src/app/features/registrations/ui/registration-cancel-dialog/registration-cancel-dialog.component.ts
+++ b/frontend/src/app/features/registrations/ui/registration-cancel-dialog/registration-cancel-dialog.component.ts
@@ -12,7 +12,7 @@ import { EventRegistration } from '../../models/event-registration.model';
   selector: 'app-registration-cancel-dialog',
   imports: [MatButtonModule, RegistrationCardComponent, NextButtonComponent],
   templateUrl: './registration-cancel-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './registration-cancel-dialog.component.scss',
 })
 export class RegistrationCancelDialogComponent {

--- a/frontend/src/app/features/registrations/ui/registration-card/registration-card.component.ts
+++ b/frontend/src/app/features/registrations/ui/registration-card/registration-card.component.ts
@@ -8,7 +8,7 @@ import { RegistrationRequestTicket } from '../../models/registration-request-tic
   selector: 'app-registration-card',
   imports: [EventLocationCard, EventOpportunityCardComponent],
   templateUrl: './registration-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './registration-card.component.scss',
 })
 export class RegistrationCardComponent {

--- a/frontend/src/app/features/registrations/ui/registration-manage-dialog/registration-manage-dialog.component.ts
+++ b/frontend/src/app/features/registrations/ui/registration-manage-dialog/registration-manage-dialog.component.ts
@@ -13,7 +13,7 @@ import { EventRegistration } from '../../models/event-registration.model';
   selector: 'app-registration-manage-dialog',
   imports: [MatButtonModule, RegistrationCardComponent, NextButtonComponent],
   templateUrl: './registration-manage-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './registration-manage-dialog.component.scss'
 })
 export class RegistrationManageDialogComponent {

--- a/frontend/src/app/features/registrations/ui/registration-request-button/registration-request-button.component.ts
+++ b/frontend/src/app/features/registrations/ui/registration-request-button/registration-request-button.component.ts
@@ -13,7 +13,7 @@ import { RegistrationRequestDialogComponent } from '../registration-request-dial
   selector: 'app-registration-request-button',
   imports: [TitleCasePipe, NextButtonComponent],
   templateUrl: './registration-request-button.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './registration-request-button.component.scss'
 })
 export class RegistrationRequestButtonComponent {

--- a/frontend/src/app/features/registrations/ui/registration-request-dialog/registration-request-dialog.component.ts
+++ b/frontend/src/app/features/registrations/ui/registration-request-dialog/registration-request-dialog.component.ts
@@ -16,7 +16,7 @@ import { delay, finalize } from 'rxjs';
   selector: 'app-registration-request-dialog',
   imports: [MatButtonModule, LoadingSpinnerComponent, RegistrationCardComponent, NextButtonComponent, RouterLink],
   templateUrl: './registration-request-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './registration-request-dialog.component.scss',
 })
 export class RegistrationRequestDialogComponent {

--- a/frontend/src/app/features/registrations/ui/registration-status-card/registration-status-card.component.ts
+++ b/frontend/src/app/features/registrations/ui/registration-status-card/registration-status-card.component.ts
@@ -12,7 +12,7 @@ import { RegistrationManageDialogComponent } from '../registration-manage-dialog
   selector: 'app-registration-status-card',
   imports: [DatePipe, RouterLink, NextButtonComponent],
   templateUrl: './registration-status-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './registration-status-card.component.scss',
 })
 export class RegistrationStatusCardComponent {

--- a/frontend/src/app/features/user/pages/user-dashboard/event-registrations/event-registration-card/event-registration-card.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/event-registrations/event-registration-card/event-registration-card.component.ts
@@ -12,7 +12,7 @@ import { EventRegistrationStatusComponent } from './event-registration-status/ev
   selector: 'app-event-registration-card',
   imports: [NgOptimizedImage, EventLocationCard, EventOpportunityCardComponent, EventRegistrationStatusComponent, NextButtonComponent, RouterLink],
   templateUrl: './event-registration-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-registration-card.component.scss'
 })
 export class EventRegistrationCardComponent implements OnInit {

--- a/frontend/src/app/features/user/pages/user-dashboard/event-registrations/event-registration-card/event-registration-status/event-registration-status.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/event-registrations/event-registration-card/event-registration-status/event-registration-status.component.ts
@@ -5,7 +5,7 @@ import { RegistrationStatus } from '@app/features/registrations/models/event-reg
   selector: 'app-event-registration-status',
   imports: [],
   templateUrl: './event-registration-status.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './event-registration-status.component.scss'
 })
 export class EventRegistrationStatusComponent {

--- a/frontend/src/app/features/user/pages/user-dashboard/manage-subscription/manage-subscription.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/manage-subscription/manage-subscription.component.ts
@@ -9,7 +9,7 @@ import SUBSCRIPTION_PLANS, { SubscriptionPlan } from '@app/features/user/models/
   selector: 'app-manage-subscription',
   imports: [SelectPlanComponent, PlanPaymentComponent],
   templateUrl: './manage-subscription.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './manage-subscription.component.scss'
 })
 export class ManageSubscriptionComponent implements OnChanges {

--- a/frontend/src/app/features/user/pages/user-dashboard/profile-badges/profile-badges.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/profile-badges/profile-badges.component.ts
@@ -13,7 +13,7 @@ import { UserProfileService } from '@app/features/user/services/user-profile.ser
   selector: 'app-profile-badges',
   imports: [DatePipe, MatTableModule, MatTooltipModule],
   templateUrl: './profile-badges.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './profile-badges.component.scss'
 })
 export class ProfileBadgesComponent implements OnInit {

--- a/frontend/src/app/features/user/pages/user-dashboard/profile-dialog/profile-dialog.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/profile-dialog/profile-dialog.component.ts
@@ -26,7 +26,7 @@ interface UserProfileForm {
   imports: [FormField, MatButtonModule, MatRippleModule, MatInputModule,
     MatFormFieldModule, MatSelectModule, UserAvatarComponent],
   templateUrl: './profile-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './profile-dialog.component.scss'
 })
 export class ProfileDialogComponent implements OnInit {

--- a/frontend/src/app/features/user/pages/user-dashboard/suggested-events/suggested-event-card/suggested-event-card.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/suggested-events/suggested-event-card/suggested-event-card.component.ts
@@ -11,7 +11,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-suggested-event-card',
   imports: [NgOptimizedImage, EventLikeButtonComponent, EventShareButtonComponent, NextButtonComponent, RouterLink],
   templateUrl: './suggested-event-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './suggested-event-card.component.scss'
 })
 export class SuggestedEventCardComponent {

--- a/frontend/src/app/features/user/pages/user-dashboard/suggested-events/suggested-events.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/suggested-events/suggested-events.component.ts
@@ -9,7 +9,7 @@ import { SuggestedEventCardComponent } from "./suggested-event-card/suggested-ev
   selector: 'app-suggested-events',
   imports: [SuggestedEventCardComponent],
   templateUrl: './suggested-events.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './suggested-events.component.scss'
 })
 export class SuggestedEventsComponent implements OnInit {

--- a/frontend/src/app/features/user/pages/user-dashboard/user-dashboard.component.ts
+++ b/frontend/src/app/features/user/pages/user-dashboard/user-dashboard.component.ts
@@ -42,7 +42,7 @@ export class UserDashboardComponent implements OnInit {
   private router = inject(Router);
   private dialogService = inject(DialogService);
 
-  user = signal<User | null>(null);
+  user = computed(() => this.auth.user());
   avatar = computed(() => {
     const user = this.user();
     if (user && !user!.image.id) {
@@ -66,8 +66,7 @@ export class UserDashboardComponent implements OnInit {
   };
 
   ngOnInit(): void {
-    if (this.auth.user()) {
-      this.user.set(this.auth.user()!);
+    if (this.user()) {
       this.title.setTitle(`${this.user()?.firstName} ${this.user()?.lastName}`);
       const description = "View and manage your user setting in Next Japan. See your next event and achievements!";
       this.meta.updateTags(this.title.getTitle(), description);

--- a/frontend/src/app/features/user/ui/avatar/avatar.component.ts
+++ b/frontend/src/app/features/user/ui/avatar/avatar.component.ts
@@ -7,7 +7,7 @@ import { ImageService } from '@app/core/services/image.service';
   selector: 'app-avatar',
   imports: [NgOptimizedImage],
   templateUrl: './avatar.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './avatar.component.scss'
 })
 export class AvatarComponent {

--- a/frontend/src/app/features/user/ui/avatar/user-avatar/user-avatar.component.ts
+++ b/frontend/src/app/features/user/ui/avatar/user-avatar/user-avatar.component.ts
@@ -6,7 +6,7 @@ import { AvatarComponent } from "../avatar.component";
   selector: 'app-user-avatar',
   imports: [AvatarComponent],
   templateUrl: './user-avatar.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './user-avatar.component.scss',
 })
 export class UserAvatarComponent {

--- a/frontend/src/app/features/user/ui/my-notifications/notification-card/notification-card.component.ts
+++ b/frontend/src/app/features/user/ui/my-notifications/notification-card/notification-card.component.ts
@@ -10,7 +10,7 @@ import { environment } from '@environments/environment';
   selector: 'app-notification-card',
   imports: [NgOptimizedImage],
   templateUrl: './notification-card.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './notification-card.component.scss'
 })
 export class NotificationCardComponent {

--- a/frontend/src/app/features/user/ui/user-navbar/user-menu/user-menu.component.ts
+++ b/frontend/src/app/features/user/ui/user-navbar/user-menu/user-menu.component.ts
@@ -14,7 +14,7 @@ import { of, switchMap } from 'rxjs';
   selector: 'app-user-menu',
   imports: [RouterLink, MatButtonModule, MatMenuModule, MatTooltipModule, UserAvatarComponent],
   templateUrl: './user-menu.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './user-menu.component.scss'
 })
 export class UserMenuComponent {

--- a/frontend/src/app/features/user/ui/user-navbar/user-navbar.component.ts
+++ b/frontend/src/app/features/user/ui/user-navbar/user-navbar.component.ts
@@ -14,7 +14,7 @@ import { UserMenuComponent } from "./user-menu/user-menu.component";
   selector: 'app-user-navbar',
   imports: [MatMenuModule, MyNotificationsComponent, AppLogoComponent, UserMenuComponent, EventSearchAutocompleteComponent, NextButtonComponent, RouterLink],
   templateUrl: './user-navbar.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './user-navbar.component.scss'
 })
 export class UserNavbarComponent {

--- a/frontend/src/app/pages/about-this-project/my-resume/my-resume.component.ts
+++ b/frontend/src/app/pages/about-this-project/my-resume/my-resume.component.ts
@@ -8,7 +8,7 @@ import { MarkdownModule } from 'ngx-markdown';
   selector: 'app-my-resume',
   imports: [MarkdownModule, DialogComponent, NextButtonComponent],
   templateUrl: './my-resume.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './my-resume.component.scss'
 })
 export class MyResumeComponent {

--- a/frontend/src/app/pages/home/about-site-banner/about-site-banner.component.ts
+++ b/frontend/src/app/pages/home/about-site-banner/about-site-banner.component.ts
@@ -6,7 +6,7 @@ import { ImageService } from '@app/core/services/image.service';
   selector: 'app-about-site-banner',
   imports: [NgOptimizedImage],
   templateUrl: './about-site-banner.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './about-site-banner.component.scss'
 })
 export class AboutSiteBannerComponent {

--- a/frontend/src/app/pages/home/ai-banner/ai-banner.component.ts
+++ b/frontend/src/app/pages/home/ai-banner/ai-banner.component.ts
@@ -9,7 +9,7 @@ import { NextButtonComponent } from "@app/shared/ui/next-button/next-button.comp
   selector: 'app-ai-banner',
   imports: [NgOptimizedImage, NextButtonComponent, RouterLink],
   templateUrl: './ai-banner.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './ai-banner.component.scss',
 })
 export class AiBannerComponent {

--- a/frontend/src/app/pages/legal/acceptable-use/acceptable-use.component.ts
+++ b/frontend/src/app/pages/legal/acceptable-use/acceptable-use.component.ts
@@ -6,7 +6,7 @@ import { MetaService } from '@app/core/services/meta.service';
   selector: 'app-acceptable-use',
   imports: [],
   templateUrl: './acceptable-use.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './acceptable-use.component.scss'
 })
 export class AcceptableUseComponent {

--- a/frontend/src/app/pages/legal/cookie-policy/cookie-policy.component.ts
+++ b/frontend/src/app/pages/legal/cookie-policy/cookie-policy.component.ts
@@ -6,7 +6,7 @@ import { MetaService } from '@app/core/services/meta.service';
   selector: 'app-cookie-policy',
   imports: [],
   templateUrl: './cookie-policy.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './cookie-policy.component.scss'
 })
 export class CookiePolicyComponent {

--- a/frontend/src/app/pages/legal/privacy/privacy.component.ts
+++ b/frontend/src/app/pages/legal/privacy/privacy.component.ts
@@ -6,7 +6,7 @@ import { MetaService } from '@app/core/services/meta.service';
   selector: 'app-privacy',
   imports: [],
   templateUrl: './privacy.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './privacy.component.scss'
 })
 export class PrivacyComponent {

--- a/frontend/src/app/pages/legal/terms-of-service/terms-of-service.component.ts
+++ b/frontend/src/app/pages/legal/terms-of-service/terms-of-service.component.ts
@@ -6,7 +6,7 @@ import { MetaService } from '@app/core/services/meta.service';
   selector: 'app-terms-of-service',
   imports: [],
   templateUrl: './terms-of-service.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './terms-of-service.component.scss'
 })
 export class TermsOfServiceComponent {

--- a/frontend/src/app/shared/ui/button/button.component.ts
+++ b/frontend/src/app/shared/ui/button/button.component.ts
@@ -6,7 +6,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   selector: 'app-button',
   imports: [MatRippleModule, MatTooltipModule],
   templateUrl: './button.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './button.component.scss'
 })
 export class ButtonComponent {

--- a/frontend/src/app/shared/ui/dialog/dialog.component.ts
+++ b/frontend/src/app/shared/ui/dialog/dialog.component.ts
@@ -9,7 +9,7 @@ import { filter } from 'rxjs';
   standalone: true,
   imports: [],
   templateUrl: './dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './dialog.component.scss',
 })
 export class DialogComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/shared/ui/loading-spinner/loading-spinner.component.ts
+++ b/frontend/src/app/shared/ui/loading-spinner/loading-spinner.component.ts
@@ -5,7 +5,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
   selector: 'app-loading-spinner',
   imports: [MatProgressSpinnerModule],
   templateUrl: './loading-spinner.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './loading-spinner.component.scss',
 })
 export class LoadingSpinnerComponent implements OnInit {

--- a/frontend/src/app/shared/ui/next-button/next-button.component.ts
+++ b/frontend/src/app/shared/ui/next-button/next-button.component.ts
@@ -18,7 +18,7 @@ import { MatTooltip, MatTooltipModule } from '@angular/material/tooltip';
     'class': 'app-button',
     '[attr.data-variant]': 'variant()', // This "links" the TS to the CSS
   },
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./next-button.component.scss']
 })
 export class NextButtonComponent {

--- a/frontend/src/app/shared/ui/page-load-spinner/page-load-spinner.component.ts
+++ b/frontend/src/app/shared/ui/page-load-spinner/page-load-spinner.component.ts
@@ -6,7 +6,7 @@ import { NgxSpinnerComponent, NgxSpinnerService } from 'ngx-spinner';
   imports: [NgxSpinnerComponent],
   templateUrl: './page-load-spinner.component.html',
   styleUrl: './page-load-spinner.component.scss',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.removed]': 'remove()'
   }


### PR DESCRIPTION
Converts the 61 remaining Default-strategy components left over from the Angular 22 update, and fixes two latent reactivity bugs surfaced by the switch: an in-place array mutation in the event carousel's sort, and a direct signal-object mutation in the plan payment flow. Also fixes user-dashboard's user signal, which was snapshotting auth.user() once instead of deriving it reactively, so the subscription badge never reflected a plan change.